### PR TITLE
remove duplicate key to silence ruby 2.2 warning

### DIFF
--- a/lib/ipaddr_extensions.rb
+++ b/lib/ipaddr_extensions.rb
@@ -659,7 +659,6 @@ class IPProtocol
     81 => "VMTP",
     82 => "SECURE-VMTP",
     83 => "VINES",
-    84 => "TTP",
     84 => "IPTM",
     85 => "NSFNET-IGP",
     86 => "DGP",


### PR DESCRIPTION
Fix this warning under ruby 2.2 by deleting the `84 => "TTP"` entry in the `IPProtocol::NAMES` hash, which is overwritten by the the `84 => "IPTM"` entry.

```
$ ruby --version
ruby 2.2.0p0 (2014-12-25 revision 49005) [x86_64-darwin14]
$ irb
2.2.0 :001 > require 'ipaddr_extensions'
/Users/seanwalbran/.rvm/gems/ruby-2.2.0@socialcast/gems/ipaddr_extensions-1.0.1/lib/ipaddr_extensions.rb:643: warning: duplicated key at line 644 ignored: 84
 => true
2.2.0 :002 > IPProtocol::NAMES[84]
 => "IPTM"
```
